### PR TITLE
Warn against adding "current" option to census year selection

### DIFF
--- a/CensusExternalModule.php
+++ b/CensusExternalModule.php
@@ -73,11 +73,6 @@ class CensusExternalModule extends AbstractExternalModule
 	}
 
 	function getSharedArgs($censusYear){
-		// NOTE: int casting on non-numeric strings (and nulls) defaults to 0
-		// thus current census data is effectively default behavior
-		if ((int)$censusYear === 0) {
-			return "benchmark=Public_AR_Current&vintage=Current_Current&format=json";
-		}
 		return "benchmark=Public_AR_Current&vintage=Census".((int)$censusYear)."_Current&format=json";
 	}
 

--- a/CensusExternalModule.php
+++ b/CensusExternalModule.php
@@ -73,6 +73,11 @@ class CensusExternalModule extends AbstractExternalModule
 	}
 
 	function getSharedArgs($censusYear){
+		// NOTE: int casting on non-numeric strings (and nulls) defaults to 0
+		// thus current census data is effectively default behavior
+		if ((int)$censusYear === 0) {
+			return "benchmark=Public_AR_Current&vintage=Current_Current&format=json";
+		}
 		return "benchmark=Public_AR_Current&vintage=Census".((int)$censusYear)."_Current&format=json";
 	}
 

--- a/config.json
+++ b/config.json
@@ -75,8 +75,8 @@
 					"key": "year",
 					"name": "Year",
 					"type": "dropdown",
+					"developer_comment": "Please do not attempt to add a 'current' choice; despite census.gov supporting it, this has broken things in the past due to changes in their API",
 					"choices": [
-						{ "value": "current", "name": "Current" },
 						{ "value": "2020", "name": "2020" },
 						{ "value": "2010", "name": "2010" }
 					]

--- a/config.json
+++ b/config.json
@@ -76,6 +76,7 @@
 					"name": "Year",
 					"type": "dropdown",
 					"choices": [
+						{ "value": "current", "name": "Current" },
 						{ "value": "2020", "name": "2020" },
 						{ "value": "2010", "name": "2010" }
 					]


### PR DESCRIPTION
This change is motivated by a request to add 2023 as an option, however the `Census2023_Current` is not in the API's domain for the `vintage` param:

https://github.com/vanderbilt-redcap/Census-Tract-Geocoding-External-Module/blob/40d7d912d3da6a7396471aa55a4cbb8a457e5ff9/CensusExternalModule.php#L76

Adding this "current" option was lower hanging fruit than fetching the domain and/or mapping years to valid `benchmark` and `vintage` inputs (let alone the effort of understanding government acronyms).