### PR TITLE
Add ACS2023 vintage and logic for non census conduction years

### DIFF
--- a/CensusExternalModule.php
+++ b/CensusExternalModule.php
@@ -73,7 +73,20 @@ class CensusExternalModule extends AbstractExternalModule
 	}
 
 	function getSharedArgs($censusYear){
-		return "benchmark=Public_AR_Current&vintage=Census".((int)$censusYear)."_Current&format=json";
+		$censusYear = (int)$censusYear;
+		// NOTE: The US census is conducted every 10 years on years ending in 0
+		$mostRecentCensusYear = floor($censusYear / 10) * 10;
+		if ($mostRecentCensusYear !== $censusYear) {
+			// NOTE: vintage Census<mostRecentCensusYear> is chosen for similarity to Census2020_Current scheme, namely the presence of data in "Census Blocks" field of API results
+			// see comments on related PR for further details
+			// https://github.com/vanderbilt-redcap/Census-Tract-Geocoding-External-Module/pull/3
+			$benchmark = "Public_AR_ACS{$censusYear}";
+			$vintage = "Census{$mostRecentCensusYear}_ACS{$censusYear}";
+		} else {
+			$benchmark = "Public_AR_Current";
+			$vintage = "Census{$censusYear}_Current";
+		}
+		return "benchmark={$benchmark}&vintage={$vintage}&format=json";
 	}
 
 	function addScript($project_id, $record, $instrument, $event_id, $group_id, $survey_hash = null, $response_id = null) {

--- a/CensusExternalModule.php
+++ b/CensusExternalModule.php
@@ -79,7 +79,7 @@ class CensusExternalModule extends AbstractExternalModule
 		if ($mostRecentCensusYear !== $censusYear) {
 			// NOTE: vintage Census<mostRecentCensusYear> is chosen for similarity to Census2020_Current scheme, namely the presence of data in "Census Blocks" field of API results
 			// see comments on related PR for further details
-			// https://github.com/vanderbilt-redcap/Census-Tract-Geocoding-External-Module/pull/3
+			// https://github.com/vanderbilt-redcap/Census-Tract-Geocoding-External-Module/pull/4
 			$benchmark = "Public_AR_ACS{$censusYear}";
 			$vintage = "Census{$mostRecentCensusYear}_ACS{$censusYear}";
 		} else {

--- a/config.json
+++ b/config.json
@@ -77,6 +77,7 @@
 					"type": "dropdown",
 					"developer_comment": "Please do not attempt to add a 'current' choice; despite census.gov supporting it, this has broken things in the past due to changes in their API",
 					"choices": [
+						{ "value": "2023", "name": "2023" },
 						{ "value": "2020", "name": "2020" },
 						{ "value": "2010", "name": "2010" }
 					]


### PR DESCRIPTION
This is an addition of ACS2023 data requested specifically by a client.

<details>
<summary>Communication from client</summary>

> [...] <p class="MsoNormal" style="margin: 0in; font-size: 12pt; font-family: Aptos, sans-serif; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><span style="font-size: 11pt; font-family: Calibri, sans-serif;">The benchmark is the time period when a snapshot of census geocoder data was created (generally done twice a year). The geocoder allows a user to choose to geocode their single or batch addresses to different benchmarks that are related to different Census data products. The options listed below show common benchmarks the user can choose from:

Benchmark | Description
-- | --
Public_AR_Current | Most current address range data.
Public_AR_ACS2023 | American Community Survey contains the prior year address range data. These surveys are produced every year.
Public_AR_Census2020 | Address range data from the specified decennial census like 2020.

> <p class="MsoNormal" style="margin: 0in; font-size: 12pt; font-family: Aptos, sans-serif; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><span style="font-size: 11pt; font-family: Calibri, sans-serif;"><o:p> </o:p></span></p><p class="MsoNormal" style="margin: 0in; font-size: 12pt; font-family: Aptos, sans-serif; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><span style="font-size: 11pt; font-family: Calibri, sans-serif;">The Vintage selection option enables users to select the geographies that were in place for a specific survey or Census within the FIND GEOGRAPHIES options of the Census Geocoder. For example, if a user selected “ACS2019_Current” the geocoding results returned by the geocoder would reflect geography in place at the time of the 2019 American Community Survey (ACS). In this example, any geography that did not exist or changed after the 2019 ACS benchmark (such as a city changing a boundary), would not be included in the results returned by the geocoder.<o:p></o:p></span></p><p class="MsoNormal" style="margin: 0in; font-size: 12pt; font-family: Aptos, sans-serif; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><span style="font-size: 11pt; font-family: Calibri, sans-serif;"><o:p> </o:p></span></p><p class="MsoNormal" style="margin: 0in; font-size: 12pt; font-family: Aptos, sans-serif; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;"><span style="font-size: 11pt; font-family: Calibri, sans-serif;">Per discussion with PIs, we prefer not to pick “Current” option since this current can indicate different years if our study enrolls subjects across multiple years (see Vintage options below).  The postfixes after “_” in vintage options indicates benchmarks. </span></p>

> 
![image](https://github.com/user-attachments/assets/862b75ff-d919-4103-b3d5-481e1783874a)


> [...] ran batch address processing using either Census2020 or ACS2023 options, ~99% of results matched with same block information.  Therefore, we do not have a strong preference for which option to use.

</details>

---
### Files for local testing

Data dictionary with a few fields for the 3 census year options:
[census_geocoding_3_censuses_dictionary.csv](https://github.com/user-attachments/files/16240556/census_geocoding_3_censuses_dictionary.csv)

EM settings export:
[census_geocoding_3_censuses_ModuleSettingsExport_2024-07-15.zip](https://github.com/user-attachments/files/16240565/census_geocoding_3_censuses_ModuleSettingsExport_2024-07-15.zip)

---
### API endpoint link for 2023 option
https://geocoding.geo.census.gov/geocoder/geographies/onelineaddress?address=2201%20West%20End%20Ave%2C%20Nashville%2C%20TN%2C%2037240&benchmark=Public_AR_ACS2023&vintage=Census2020_ACS2023&format=json

---
### Premature (over)thinking about potential future accommodations

Despite the simple addition of `2023` to the `year` options, I strongly suspect the pattern of using `benchmark: Public_AR_ACS<year>` with `vintage: Census<nearestCensus>_ACS<year>` may be useful for other clients who need to avoid the "Current" benchmark and vintages.  
The generic path would be to make `year` a free text field along with adding a "no current" toggle, and adapt this PR's `$mostRecentCensusYear !== $censusYear` logical path to toggle on the "no current" setting. I intentionally stopped short of this as it is much less effort to simply add additional value to the `year` dropdown as opposed to a major module version update to accommodate the alteration of the `year` field type, but I mention it here in case this request isn't as rare as I am assuming it will be.