### PR TITLE
Cast mostRecentCensusYear as int to ensure strict comparison isn't always false

### DIFF
--- a/CensusExternalModule.php
+++ b/CensusExternalModule.php
@@ -75,7 +75,7 @@ class CensusExternalModule extends AbstractExternalModule
 	function getSharedArgs($censusYear){
 		$censusYear = (int)$censusYear;
 		// NOTE: The US census is conducted every 10 years on years ending in 0
-		$mostRecentCensusYear = floor($censusYear / 10) * 10;
+		$mostRecentCensusYear = (int) (floor($censusYear / 10) * 10);
 		if ($mostRecentCensusYear !== $censusYear) {
 			// NOTE: vintage Census<mostRecentCensusYear> is chosen for similarity to Census2020_Current scheme, namely the presence of data in "Census Blocks" field of API results
 			// see comments on related PR for further details


### PR DESCRIPTION
A smarter programmer might have realized that `(double) 2010 !== (int) 2010` is always true.  
I added strict type requirement at the end of testing and it bit me :(